### PR TITLE
fix: :bug: fix manual Response to auto map when redirect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,7 +303,9 @@ const oauth2 = <Profiles extends string>({
 
 				await storage.set(ctx, (ctx.params as TOAuth2Params).name, token)
 
-				return redirect(redirectTo)
+				ctx.set.status = 'Found'
+				ctx.set.redirect = redirectTo;
+				return ''
 			})
 
 			// >>> LOGOUT <<<
@@ -316,7 +318,9 @@ const oauth2 = <Profiles extends string>({
 
 				await storage.delete(ctx, (ctx.params as TOAuth2Params).name)
 
-				return redirect(redirectTo)
+				ctx.set.status = 'Found'
+				ctx.set.redirect = redirectTo;
+				return ''
 			})
 
 			// >>> CONTEXT API <<<


### PR DESCRIPTION
Hey @bogeychan, I'm over here again.

I was facing an issue while trying to set a session Cookie using `@elysiajs/cookie` and this package.

After looking around I found that ElysiaJS always try to parse Handlers to Response at the end of cycle so I'm setting the Redirects to Auto map just returning an empty string otherwise my headers with cookies didn't go to the client.